### PR TITLE
dockerize local dev; pull firebase settings from environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM golang:1.20-alpine AS genconplanner-base
+
+WORKDIR /usr/src/app
+
+# pre-copy/cache go.mod for pre-downloading dependencies and only redownloading them in subsequent builds if they change
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY ./internal ./internal
+COPY ./cmd ./cmd
+
+
+
+# --------------------------
+FROM genconplanner-base AS update
+
+RUN go build -o /usr/local/bin/update ./cmd/update
+CMD ["/bin/sh", "-c", "/usr/local/bin/update -db=postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@db:5432/$POSTGRES_DB?sslmode=disable"]
+
+
+
+# --------------------------
+FROM genconplanner-base AS web
+
+COPY ./templates ./templates
+COPY ./static ./static
+RUN go build -o /usr/local/bin/web ./cmd/web
+
+EXPOSE 8080
+
+CMD ["/bin/sh", "-c", "/usr/local/bin/web -port=8080 -db=postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@db:5432/$POSTGRES_DB?sslmode=disable"]

--- a/README
+++ b/README
@@ -1,6 +1,0 @@
-Getting started:
-* clone repo
-* Install Heroku
-* Install Postgres following instructions here: https://devcenter.heroku.com/articles/heroku-postgresql#set-up-postgres-on-mac
-To run server locally with Heroku, use `./build.sh && heroku local web`
-To update the event listing locally, use `./build.sh && heroku local update`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Firebase Setup
+
+Create an account on [Firebase](https://firebase.google.com/):
+
+1. Click "Get Started"
+2. Click "Add Project", and set a name. Click "Continue"
+3. Decline Google Analytics, and click "Continue"
+4. Click "Authentication", then "Get Started"
+5. Click "Google" under Additional Providers; click the toggle to enable,
+then select an email address, and click "Save"
+6. Click the gear icon next to Project Overview, and select "Project
+Settings"
+7. Click the "Service Accounts" tab, then click "Create Service Account"
+8. Select "Go" then click "Generate new private key"
+9. Save the resulting JSON file
+10. Click the "General" tab, then click the `</>` icon to set up a new web
+app integration
+11. Choose a name, then click "Register App". Copy the `const
+firebaseConfig` that it generates for you
+
+## Environment Variables
+
+```
+export FIREBASE_CONFIG=... # the contents of the JSON file from step 9, as a single line
+
+# these values come from the const firebaseConfig object you generated in step 11
+export FIREBASE_API_KEY=...
+export FIREBASE_AUTH_DOMAIN=...
+export FIREBASE_DATABASE_URL=...
+export FIREBASE_PROJECT_ID=...
+export FIREBASE_STORAGE_BUCKET=...
+export FIREBASE_MESSAGING_SENDER_ID=...
+```
+
+Use [direnv](https://direnv.net/) to make this convenient so that you don't
+have to re-export these values into your environment each time you work on
+Gencon Planner
+
+
+# Dev Env Setup
+
+* Install [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+* Start the database in the background:
+    $ docker compose up -d db
+* Start the web server in the forgreound
+    $ docker build --target web .
+    $ docker compose up web
+
+The web container depends upon the `update` container, which will download &
+parse the events spreadsheet from gencon.com in the background.
+
+To reset all state, use `docker compose down -v` to clear the DB data
+volume, then follow the above steps again
+
+
+## Alternate Dev Env
+
+This setup uses a local postgres database and the `heroku` command. It may
+be more like the true run-time environment than the Docker version above.
+
+* Install Heroku
+* Install Postgres following instructions here: https://devcenter.heroku.com/articles/heroku-postgresql#set-up-postgres-on-mac
+
+To run server locally with Heroku, use `./build.sh && heroku local web`
+
+To update the event listing locally, use `./build.sh && heroku local update`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+# vim:ts=2:
+version: '3'
+services:
+
+  update:
+    build:
+      dockerfile: ./Dockerfile
+      target: update
+    restart: on-failure
+    links:
+    - db
+    environment:
+    - POSTGRES_DB=genconplanner
+    - POSTGRES_USER=postgres
+    - POSTGRES_PASSWORD=g3nc0n
+
+  web:
+    build:
+      dockerfile: ./Dockerfile
+      target: web
+    restart: on-failure
+    ports:
+    - "8080:8080"
+    links:
+    - db
+    depends_on:
+    - update
+    environment:
+    - POSTGRES_DB=genconplanner
+    - POSTGRES_USER=postgres
+    - POSTGRES_PASSWORD=g3nc0n
+    - FIREBASE_CONFIG=${FIREBASE_CONFIG}
+    - FIREBASE_API_KEY=${FIREBASE_API_KEY}
+    - FIREBASE_AUTH_DOMAIN=${FIREBASE_AUTH_DOMAIN}
+    - FIREBASE_DATABASE_URL=${FIREBASE_DATABASE_URL}
+    - FIREBASE_PROJECT_ID=${FIREBASE_PROJECT_ID}
+    - FIREBASE_STORAGE_BUCKET=${FIREBASE_STORAGE_BUCKET}
+    - FIREBASE_MESSAGING_SENDER_ID=${FIREBASE_MESSAGING_SENDER_ID}
+
+  db:
+    image: "postgres:15-alpine"
+    restart: on-failure
+    volumes:
+    - db_data:/var/lib/postgresql/data
+    - ./internal/postgres/schema.sql:/docker-entrypoint-initdb.d/schema.sql
+    environment:
+    - POSTGRES_DB=genconplanner
+    - POSTGRES_USER=postgres
+    - POSTGRES_PASSWORD=g3nc0n
+    ports:
+    - "5432:5432"
+
+volumes:
+  db_data:

--- a/internal/web/util.go
+++ b/internal/web/util.go
@@ -7,9 +7,19 @@ import (
 	"github.com/Encinarus/genconplanner/internal/postgres"
 	"github.com/gin-gonic/gin"
 	"log"
+	"os"
 	"sort"
 	"strings"
 )
+
+type FirebaseConfig struct {
+	ApiKey            string
+	AuthDomain        string
+	DatabaseURL       string
+	MessagingSenderId string
+	ProjectId         string
+	StorageBucket     string
+}
 
 type Context struct {
 	Year        int
@@ -17,6 +27,7 @@ type Context struct {
 	Email       string
 	Starred     *postgres.UserStarredEvents
 	User        *postgres.User
+	Firebase    FirebaseConfig
 }
 
 func BootstrapContext(app *firebase.App, db *sql.DB) gin.HandlerFunc {
@@ -56,6 +67,8 @@ func BootstrapContext(app *firebase.App, db *sql.DB) gin.HandlerFunc {
 				}
 			}
 		}
+
+		appContext.Firebase = getFirebaseConfig()
 
 		c.Set("context", &appContext)
 		c.Next()
@@ -132,4 +145,22 @@ func GenconEndDate(year int) string {
 		return "2019-08-04"
 	}
 	return dates[1]
+}
+
+func getEnvWithDefault(key, dflt string) string {
+	if val, set := os.LookupEnv(key); set {
+		return val
+	}
+	return dflt
+}
+
+func getFirebaseConfig() FirebaseConfig {
+	return FirebaseConfig{
+		ApiKey:            getEnvWithDefault("FIREBASE_API_KEY", "AIzaSyAGtjwGiHYFnXE1UbzLTPeIz8Ix06WIdBs"),
+		AuthDomain:        getEnvWithDefault("FIREBASE_AUTH_DOMAIN", "genconplanner-v2.firebaseapp.com"),
+		DatabaseURL:       getEnvWithDefault("FIREBASE_DATABASE_URL", "https://genconplanner-v2.firebaseio.com"),
+		ProjectId:         getEnvWithDefault("FIREBASE_PROJECT_ID", "genconplanner-v2"),
+		StorageBucket:     getEnvWithDefault("FIREBASE_STORAGE_BUCKET", "genconplanner-v2.appspot.com"),
+		MessagingSenderId: getEnvWithDefault("FIREBASE_MESSAGING_SENDER_ID", "630743534199"),
+	}
 }

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -28,6 +28,6 @@
   {{ end }}
 </div>
 
-{{ template "scriptFooter" }}
+{{ template "scriptFooter" .context }}
 </body>
 </html>

--- a/templates/common.html
+++ b/templates/common.html
@@ -46,6 +46,7 @@
 {{ end }}
 
 {{ define "scriptFooter" }}
+{{ $context := . }}
 <script
         src="https://code.jquery.com/jquery-3.6.0.min.js"
         integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4="
@@ -61,12 +62,12 @@
 <script>
     // Initialize Firebase
     var config = {
-        apiKey: "AIzaSyAGtjwGiHYFnXE1UbzLTPeIz8Ix06WIdBs",
-        authDomain: "genconplanner-v2.firebaseapp.com",
-        databaseURL: "https://genconplanner-v2.firebaseio.com",
-        projectId: "genconplanner-v2",
-        storageBucket: "genconplanner-v2.appspot.com",
-        messagingSenderId: "630743534199"
+        apiKey: "{{ $context.Firebase.ApiKey }}",
+        authDomain: "{{ $context.Firebase.AuthDomain }}",
+        databaseURL: "{{ $context.Firebase.DatabaseURL }}",
+        messagingSenderId: "{{ $context.Firebase.MessagingSenderId }}",
+        projectId: "{{ $context.Firebase.ProjectId }}",
+        storageBucket: "{{ $context.Firebase.StorageBucket }}",
     };
 
     function signOut() {


### PR DESCRIPTION
The development environment originally described in README should continue to work; but if you want to dev locally without having to install `heroku` or `postgres` directly onto your machine, you can now do docker things. The README.md has instructions on how to do the basic steps.

I also discovered along the way that the firebase settings need to be configurable to work with each dev's firebase account; it didn't seem to be happy trying to re-use your credentials (or it would need the server side credentials to go along with it, which don't seem safe to share in a public repo)